### PR TITLE
fix(auth) check for password length of 0

### DIFF
--- a/lib/server/auth.js
+++ b/lib/server/auth.js
@@ -36,8 +36,7 @@
             algo    = config('algo');
         
         sameName    = username === name;
-        samePass    =    (password.length > 0) 
-                      && (pass === criton(password, algo));
+        samePass    = (password.length > 0) && (pass === criton(password, algo));
         
         callback(sameName && samePass);
     }


### PR DESCRIPTION
<!--
Thank you for making pull request. Please fill in the template below. If unsure
about something, just do as best as you're able.
-->

[x] commit message named according to [Contributing Guide](https://github.com/coderaiser/cloudcmd/blob/master/CONTRIBUTING.md)
[x] `npm run codestyle` is OK
[x] `npm test` is OK

We now check for an empty password supplied to the authentication routine prior to calling the criton verification. 

Found myself in a loop when enabling authentication with a username and password, accessing the site via Chrome, and forgetting to type in a password in the authentication box. The criton throw on an empty password would continually fire until I closed the browser or attempted in an incognito window. May be a user error and/or error with Chrome insofar as the headers aren't properly cleared when the criton error is thrown - which means it could be a bigger issue requiring address.
